### PR TITLE
Update pylint and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,5 @@ min-public-methods = 0
 [tool.pylint.format]
 max-line-length = 79
 
-[tool.pylint."message control"]
-# Disable not PEP 8 compliant warnings:
-#   C0330: Wrong hanging indentation before block (add 4 spaces)
-#   C0326: Bad whitespace
-disable = ["C0330", "C0326"]
-
 [tool.pylint.similarities]
 ignore-imports = true

--- a/src/vutils/cli/__init__.pyi
+++ b/src/vutils/cli/__init__.pyi
@@ -8,7 +8,8 @@
 #
 
 import pathlib
-from typing import Callable, NoReturn, Protocol, TextIO
+from collections.abc import Callable
+from typing import NoReturn, Protocol, TextIO
 
 from typing_extensions import TypeAlias
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -9,14 +9,12 @@
 """Test `vutils.cli.application` module."""
 
 from vutils.testing.testcase import TestCase
-from vutils.testing.utils import cover_typing
 
 from vutils.cli.application import ApplicationMixin
 
 from .common import (
     ERR_TEST,
     MESSAGE,
-    SYMBOLS,
     ApplicationA,
     ErrorA,
     ErrorB,
@@ -24,8 +22,6 @@ from .common import (
     on_error_log,
     on_exit_log,
 )
-
-cover_typing("vutils.cli.application", SYMBOLS)
 
 
 class ApplicationMixinTestCase(TestCase):

--- a/tests/unit/test_coverage.py
+++ b/tests/unit/test_coverage.py
@@ -1,0 +1,28 @@
+#                                                         -*- coding: utf-8 -*-
+# File:    ./tests/unit/test_coverage.py
+# Author:  Jiří Kučera <sanczes AT gmail.com>
+# Date:    2022-06-04 15:55:57 +0200
+# Project: vutils-cli: Auxiliary library for writing CLI applications
+#
+# SPDX-License-Identifier: MIT
+#
+"""Coverage tests."""
+
+import pytest
+from vutils.testing.utils import cover_typing
+
+from .common import SYMBOLS
+
+
+@pytest.mark.order("last")
+def test_typing_code_is_covered():
+    """
+    Ensure typing code coverage.
+
+    This is a dummy test that executes `cover_typing` to ensure that the code
+    under ``if TYPE_CHECKING:`` branch is covered. Since `cover_typing` reloads
+    the module, run this test as last to prevent mangling of yet imported
+    modules.
+    """
+    cover_typing("vutils.cli.application", SYMBOLS)
+    cover_typing("vutils.cli.logging", SYMBOLS)

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -9,7 +9,7 @@
 """Test `vutils.cli.logging` module."""
 
 from vutils.testing.testcase import TestCase
-from vutils.testing.utils import LazyInstance, cover_typing
+from vutils.testing.utils import LazyInstance
 
 from vutils.cli.io import brown
 from vutils.cli.logging import LogFormatter
@@ -24,13 +24,10 @@ from .common import (
     CS_RESET_ALL,
     LOGFILE,
     MESSAGE,
-    SYMBOLS,
     UKEY,
     LoggerB,
     ModulePatcher,
 )
-
-cover_typing("vutils.cli.logging", SYMBOLS)
 
 
 class LogFormatterTestCase(TestCase):

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -8,13 +8,15 @@
 #
 """Test `vutils.cli.version` module."""
 
-import unittest
+from vutils.testing.testcase import TestCase
 
 from vutils.cli.version import __version__
 
 
-class VersionTestCase(unittest.TestCase):
+class VersionTestCase(TestCase):
     """Test case for version."""
+
+    __slots__ = ()
 
     def test_version(self):
         """Test if version is defined properly."""

--- a/tox.ini
+++ b/tox.ini
@@ -23,11 +23,12 @@ deps =
     safety
     pytest
     pytest-cov
+    pytest-order
     vutils-testing
     coveralls
 commands =
     safety check --full-report
-    pytest --cov=vutils.cli --cov-report=term-missing tests
+    pytest -v --cov=vutils.cli --cov-report=term-missing tests
     {env:COVERALLS_CMD:coveralls --output={envname}-coverage.txt}
 
 [linters]
@@ -92,6 +93,7 @@ description =
 deps =
     colorama
     pylint
+    pytest
     vutils-testing
 commands =
     pylint setup.py src/vutils/cli tests/unit


### PR DESCRIPTION
* remove deprecated `pylint` warnings
* migrate to `vutils-testing`
* fix PEP585 issue
* run `cover_typing` as last