### PR TITLE
Metadata cleanup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Software Development :: User Interfaces
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 description = Auxiliary library for writing CLI applications
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./setup.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-07-06 21:32:16 +0200

--- a/src/vutils/cli/__init__.py
+++ b/src/vutils/cli/__init__.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/cli/__init__.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-07-06 21:32:16 +0200

--- a/src/vutils/cli/__init__.pyi
+++ b/src/vutils/cli/__init__.pyi
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/cli/__init__.pyi
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-02-17 19:49:22 +0100

--- a/src/vutils/cli/application.py
+++ b/src/vutils/cli/application.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/cli/application.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-07-07 02:34:26 +0200

--- a/src/vutils/cli/errors.py
+++ b/src/vutils/cli/errors.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/cli/errors.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-07-09 22:37:01 +0200

--- a/src/vutils/cli/io.py
+++ b/src/vutils/cli/io.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/cli/io.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-07-11 16:17:41 +0200

--- a/src/vutils/cli/logging.py
+++ b/src/vutils/cli/logging.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/cli/logging.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-07-09 16:31:58 +0200

--- a/src/vutils/cli/version.py
+++ b/src/vutils/cli/version.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/cli/version.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-07-06 21:32:16 +0200

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/__init__.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-07-06 21:32:16 +0200

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/common.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-09-12 10:54:19 +0200

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_application.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-08-29 12:15:57 +0200

--- a/tests/unit/test_coverage.py
+++ b/tests/unit/test_coverage.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_coverage.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-06-04 15:55:57 +0200

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_errors.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-08-28 21:14:57 +0200

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_io.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-09-30 08:31:15 +0200

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_logging.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-09-12 20:09:34 +0200

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_version.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-07-06 21:32:16 +0200


### PR DESCRIPTION
Metadata cleanup
- remove `coding` marks (not needed in Python 3 anymore)
- use `license_files` (`license_file` is obsolete)